### PR TITLE
add ack-after-command-hook

### DIFF
--- a/ack.el
+++ b/ack.el
@@ -134,6 +134,12 @@ Used by `ack-guess-project-root'."
   :type 'hook
   :group 'ack)
 
+(defcustom ack-after-command-hook nil
+  "Hook run after ack command is finished."
+  :type 'hook
+  :group 'ack)
+
+
 ;;; ======== END of USER OPTIONS ========
 
 (defvar ack-history nil "History list for ack.")
@@ -386,7 +392,8 @@ minibuffer:
     (with-current-buffer (compilation-start command-args 'ack-mode)
       (when ack-buffer-name-function
         (rename-buffer (funcall ack-buffer-name-function "ack")))
-      (current-buffer))))
+      (current-buffer)))
+  (run-hooks 'ack-after-command-hook))
 
 (provide 'ack)
 ;;; ack.el ends here


### PR DESCRIPTION
Hi,

I have a use case where I would like a hook that runs after the ack command happens.  This PR adds a hook and uses it at the end of the autoloaded ack function.

Cheers,
B