### PR TITLE
Fix parsing of filename and line number as a result of "git grep" with filenames of the format abc-123-def.txt

### DIFF
--- a/ack.el
+++ b/ack.el
@@ -269,7 +269,7 @@ This gets tacked on the end of the generated expressions.")
      nil nil (4 compilation-column-face nil t))
     ;; None grouping line (--nogroup or --noheading). Avoid matching
     ;; 'Ack started at Thu Jun 6 12:27:53'.
-    ("^\\(.+?\\)\\(:\\|-\\)\\([1-9][0-9]*\\)\\2\\(?:\\(?:\\(?4:[1-9][0-9]*\\)\\2\\)\\|[^0-9\n]\\|[0-9][^0-9\n]\\|...\\)"
+    ("^\\(.+?\\)\\(:\\)\\([1-9][0-9]*\\)\\2\\(?:\\(?:\\(?4:[1-9][0-9]*\\)\\2\\)\\|[^0-9\n]\\|[0-9][^0-9\n]\\|...\\)"
      1 3 (ack--column-start . ack--column-end)
      nil 1 (4 compilation-column-face nil t))
     ("^Binary file \\(.+\\) matches$" 1 nil nil 0 1))


### PR DESCRIPTION
This fix resolves the issue for me, but it has not been tested extensively. I do not know the reason for including the hyphen.