### PR TITLE
removed ack-finish-functions to be consistent with grep.el

### DIFF
--- a/ack.el
+++ b/ack.el
@@ -193,9 +193,6 @@ Used by `ack-guess-project-root'."
 (defvar ack-error "ack match"
   "Stem of message to print when no matches are found.")
 
-(defvar ack-finish-functions nil
-  "Value to use for `compilation-finish-functions' in ack buffers.")
-
 (defun ack-filter ()
   "Handle match highlighting escape sequences inserted by the ack process.
 This function is called from `compilation-filter-hook'."


### PR DESCRIPTION
ack-mode implements it own compilation-finish-functions list (ack-finish-functions), which I found confusing because running ack still triggers compilation-start-hook. Indeed, this is inconsistent with  grep.el, which relies on the standard compilation-finish-functions. 

So, if I want to e.g. have a spinning [parrot](https://github.com/dp12/parrot) while a compilation process is running and the spinning is triggered via compilation-start-hook, then it would be possible to stop it again in grep.el and standard compilation-mode via compilation-finish-functions, but one would need also ate dd the stop function to ack-finish-functions, otherwise the parrot will spin forever :-o. I accept that this is probably not the most important use case, but still ...