### PR TITLE
Weird Minibuffer Display When Candidate Search Text Has Properties

### DIFF
--- a/ack.el
+++ b/ack.el
@@ -378,10 +378,10 @@ This function is a suitable addition to
 (defun ack-yank-symbol-at-point ()
   "Yank the symbol from the window before entering the minibuffer."
   (interactive)
-  (let ((symbol (and (minibuffer-selected-window)
+  (let ((symbol (substring-no-properties (and (minibuffer-selected-window)
                      (with-current-buffer
                          (window-buffer (minibuffer-selected-window))
-                       (thing-at-point 'symbol)))))
+                       (thing-at-point 'symbol))))))
     (cond (symbol (insert symbol)
                   (set (make-local-variable 'ack--yanked-symbol) symbol))
           (t (minibuffer-message "No symbol found")))))


### PR DESCRIPTION
When the candidate symbol or text to search for is copied from the current buffer to the command line in the minibuffer, text properties are copied, too. When the text has a big font size, is bold, etc. this can affect the minibuffer display in aesthetically unpleasant ways. This commit removes any text properties from the candidate symbol, so that the command line in the minibuffer retains a uniform appearance.

* ack.el (ack-yank-symbol-at-point): remove text properties from candidate symbol